### PR TITLE
Adding support for XSS domain whitelist

### DIFF
--- a/examples/owasp-top-10/main.tf
+++ b/examples/owasp-top-10/main.tf
@@ -21,4 +21,5 @@ module "owasp_top_10" {
   max_expected_cookie_size       = "4093"
   csrf_expected_header           = "x-csrf-token"
   csrf_expected_size             = "36"
+  xss_whitelist                  = []
 }

--- a/main.tf
+++ b/main.tf
@@ -224,7 +224,7 @@ resource "aws_wafregional_xss_match_set" "owasp_03_xss_set" {
 }
 
 resource "aws_wafregional_rule" "owasp_03_xss_rule" {
-  depends_on = ["aws_wafregional_xss_match_set.owasp_03_xss_set","aws_waf_byte_match_set.xsswhitelist"]
+  depends_on = ["aws_wafregional_xss_match_set.owasp_03_xss_set","aws_wafregional_byte_match_set.xsswhitelist"]
 
   count = "${lower(var.target_scope) == "regional" ? "1" : "0"}"
 
@@ -238,7 +238,7 @@ resource "aws_wafregional_rule" "owasp_03_xss_rule" {
   }
 
   predicate {
-    data_id = aws_waf_byte_match_set.xsswhitelist.0.id
+    data_id = aws_wafregional_byte_match_set.xsswhitelist.0.id
     negated = "true"
     type    = "ByteMatch"
   }    
@@ -1625,7 +1625,7 @@ resource "aws_waf_byte_match_set" "xsswhitelist" {
 
     content {
       text_transformation   = "URL_DECODE"
-      target_string         = whitelisted_source.0.value
+      target_string         = whitelisted_source.value
       positional_constraint = "EXACTLY"
 
       field_to_match {
@@ -1646,7 +1646,7 @@ resource "aws_wafregional_byte_match_set" "xsswhitelist" {
 
     content {
       text_transformation   = "URL_DECODE"
-      target_string         = whitelisted_source.0.value
+      target_string         = whitelisted_source.value
       positional_constraint = "EXACTLY"
 
       field_to_match {

--- a/main.tf
+++ b/main.tf
@@ -224,7 +224,7 @@ resource "aws_wafregional_xss_match_set" "owasp_03_xss_set" {
 }
 
 resource "aws_wafregional_rule" "owasp_03_xss_rule" {
-  depends_on = ["aws_wafregional_xss_match_set.owasp_03_xss_set"]
+  depends_on = ["aws_wafregional_xss_match_set.owasp_03_xss_set","aws_waf_byte_match_set.xsswhitelist"]
 
   count = "${lower(var.target_scope) == "regional" ? "1" : "0"}"
 
@@ -1025,7 +1025,7 @@ resource "aws_waf_xss_match_set" "owasp_03_xss_set" {
 }
 
 resource "aws_waf_rule" "owasp_03_xss_rule" {
-  depends_on = ["aws_waf_xss_match_set.owasp_03_xss_set"]
+  depends_on = ["aws_waf_xss_match_set.owasp_03_xss_set","aws_waf_byte_match_set.xsswhitelist"]
 
   count = "${lower(var.target_scope) == "global" ? "1" : "0"}"
 

--- a/variables.tf
+++ b/variables.tf
@@ -64,3 +64,9 @@ variable "csrf_expected_size" {
   description = "The size in bytes of the CSRF token value. For example if it's a canonically formatted UUIDv4 value the expected size would be 36 bytes/ASCII characters."
   default     = "36"
 }
+
+variable "xss_whitelist" {
+  type        = "list"
+  description = "A list of trusted source domains that should not be blocked by the XSS filter"
+  default     = null
+}


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

<!---
--->
This adds support for whitelisting source domains from the XSS filter. A new list variable xxs_whitelist was created.

An aws_waf_byte_match_set was created to define the servers that should be excluded from the XSS filter. A dynamic block with the whitelist entries was added to it, and finally an additional predicate block was added to both the regional and global rules. This additional predicate block uses the byte match set with a negate flag, to ensure packets with a host header matching items in the list are not blocked.

If set to null (default), an empty byte match set is created.

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-waf-owasp-top-10-rules/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

FEATURES:

* Adds support for whitlisting domains from the XSS filter.


***

Output from `terraform plan` command from changes you propose.

```
$ terraform plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.


------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.owasp_top_10.aws_waf_byte_match_set.owasp_02_auth_token_string_set[0] will be created
  + resource "aws_waf_byte_match_set" "owasp_02_auth_token_string_set" {
      + id   = (known after apply)
      + name = (known after apply)

      + byte_match_tuples {
          + positional_constraint = "ENDS_WITH"
          + target_string         = ".TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ"
          + text_transformation   = "URL_DECODE"

          + field_to_match {
              + data = "authorization"
              + type = "HEADER"
            }
        }
      + byte_match_tuples {
          + positional_constraint = "CONTAINS"
          + target_string         = "example-session-id"
          + text_transformation   = "URL_DECODE"

          + field_to_match {
              + data = "cookie"
              + type = "HEADER"
            }
        }
    }

  # module.owasp_top_10.aws_waf_byte_match_set.owasp_04_paths_string_set[0] will be created
  + resource "aws_waf_byte_match_set" "owasp_04_paths_string_set" {
      + id   = (known after apply)
      + name = (known after apply)

      + byte_match_tuples {
          + positional_constraint = "CONTAINS"
          + target_string         = "../"
          + text_transformation   = "HTML_ENTITY_DECODE"

          + field_to_match {
              + type = "QUERY_STRING"
            }
        }
      + byte_match_tuples {
          + positional_constraint = "CONTAINS"
          + target_string         = "../"
          + text_transformation   = "URL_DECODE"

          + field_to_match {
              + type = "QUERY_STRING"
            }
        }
      + byte_match_tuples {
          + positional_constraint = "CONTAINS"
          + target_string         = "://"
          + text_transformation   = "HTML_ENTITY_DECODE"

          + field_to_match {
              + type = "QUERY_STRING"
            }
        }
      + byte_match_tuples {
          + positional_constraint = "CONTAINS"
          + target_string         = "://"
          + text_transformation   = "URL_DECODE"

          + field_to_match {
              + type = "QUERY_STRING"
            }
        }
      + byte_match_tuples {
          + positional_constraint = "CONTAINS"
          + target_string         = "../"
          + text_transformation   = "HTML_ENTITY_DECODE"

          + field_to_match {
              + type = "URI"
            }
        }
      + byte_match_tuples {
          + positional_constraint = "CONTAINS"
          + target_string         = "../"
          + text_transformation   = "URL_DECODE"

          + field_to_match {
              + type = "URI"
            }
        }
      + byte_match_tuples {
          + positional_constraint = "CONTAINS"
          + target_string         = "://"
          + text_transformation   = "HTML_ENTITY_DECODE"

          + field_to_match {
              + type = "URI"
            }
        }
      + byte_match_tuples {
          + positional_constraint = "CONTAINS"
          + target_string         = "://"
          + text_transformation   = "URL_DECODE"

          + field_to_match {
              + type = "URI"
            }
        }
    }

  # module.owasp_top_10.aws_waf_byte_match_set.owasp_06_php_insecure_qs_string_set[0] will be created
  + resource "aws_waf_byte_match_set" "owasp_06_php_insecure_qs_string_set" {
      + id   = (known after apply)
      + name = (known after apply)

      + byte_match_tuples {
          + positional_constraint = "CONTAINS"
          + target_string         = "_ENV["
          + text_transformation   = "URL_DECODE"

          + field_to_match {
              + type = "QUERY_STRING"
            }
        }
      + byte_match_tuples {
          + positional_constraint = "CONTAINS"
          + target_string         = "_SERVER["
          + text_transformation   = "URL_DECODE"

          + field_to_match {
              + type = "QUERY_STRING"
            }
        }
      + byte_match_tuples {
          + positional_constraint = "CONTAINS"
          + target_string         = "allow_url_include="
          + text_transformation   = "URL_DECODE"

          + field_to_match {
              + type = "QUERY_STRING"
            }
        }
      + byte_match_tuples {
          + positional_constraint = "CONTAINS"
          + target_string         = "auto_append_file="
          + text_transformation   = "URL_DECODE"

          + field_to_match {
              + type = "QUERY_STRING"
            }
        }
      + byte_match_tuples {
          + positional_constraint = "CONTAINS"
          + target_string         = "auto_prepend_file="
          + text_transformation   = "URL_DECODE"

          + field_to_match {
              + type = "QUERY_STRING"
            }
        }
      + byte_match_tuples {
          + positional_constraint = "CONTAINS"
          + target_string         = "disable_functions="
          + text_transformation   = "URL_DECODE"

          + field_to_match {
              + type = "QUERY_STRING"
            }
        }
      + byte_match_tuples {
          + positional_constraint = "CONTAINS"
          + target_string         = "open_basedir="
          + text_transformation   = "URL_DECODE"

          + field_to_match {
              + type = "QUERY_STRING"
            }
        }
      + byte_match_tuples {
          + positional_constraint = "CONTAINS"
          + target_string         = "safe_mode="
          + text_transformation   = "URL_DECODE"

          + field_to_match {
              + type = "QUERY_STRING"
            }
        }
    }

  # module.owasp_top_10.aws_waf_byte_match_set.owasp_06_php_insecure_uri_string_set[0] will be created
  + resource "aws_waf_byte_match_set" "owasp_06_php_insecure_uri_string_set" {
      + id   = (known after apply)
      + name = (known after apply)

      + byte_match_tuples {
          + positional_constraint = "ENDS_WITH"
          + target_string         = "/"
          + text_transformation   = "URL_DECODE"

          + field_to_match {
              + type = "URI"
            }
        }
      + byte_match_tuples {
          + positional_constraint = "ENDS_WITH"
          + target_string         = "php"
          + text_transformation   = "URL_DECODE"

          + field_to_match {
              + type = "URI"
            }
        }
    }

  # module.owasp_top_10.aws_waf_byte_match_set.owasp_08_csrf_method_string_set[0] will be created
  + resource "aws_waf_byte_match_set" "owasp_08_csrf_method_string_set" {
      + id   = (known after apply)
      + name = (known after apply)

      + byte_match_tuples {
          + positional_constraint = "EXACTLY"
          + target_string         = "post"
          + text_transformation   = "LOWERCASE"

          + field_to_match {
              + type = "METHOD"
            }
        }
    }

  # module.owasp_top_10.aws_waf_byte_match_set.owasp_09_server_side_include_string_set[0] will be created
  + resource "aws_waf_byte_match_set" "owasp_09_server_side_include_string_set" {
      + id   = (known after apply)
      + name = (known after apply)

      + byte_match_tuples {
          + positional_constraint = "ENDS_WITH"
          + target_string         = ".backup"
          + text_transformation   = "LOWERCASE"

          + field_to_match {
              + type = "URI"
            }
        }
      + byte_match_tuples {
          + positional_constraint = "ENDS_WITH"
          + target_string         = ".bak"
          + text_transformation   = "LOWERCASE"

          + field_to_match {
              + type = "URI"
            }
        }
      + byte_match_tuples {
          + positional_constraint = "ENDS_WITH"
          + target_string         = ".cfg"
          + text_transformation   = "LOWERCASE"

          + field_to_match {
              + type = "URI"
            }
        }
      + byte_match_tuples {
          + positional_constraint = "ENDS_WITH"
          + target_string         = ".conf"
          + text_transformation   = "LOWERCASE"

          + field_to_match {
              + type = "URI"
            }
        }
      + byte_match_tuples {
          + positional_constraint = "ENDS_WITH"
          + target_string         = ".config"
          + text_transformation   = "LOWERCASE"

          + field_to_match {
              + type = "URI"
            }
        }
      + byte_match_tuples {
          + positional_constraint = "ENDS_WITH"
          + target_string         = ".ini"
          + text_transformation   = "LOWERCASE"

          + field_to_match {
              + type = "URI"
            }
        }
      + byte_match_tuples {
          + positional_constraint = "ENDS_WITH"
          + target_string         = ".log"
          + text_transformation   = "LOWERCASE"

          + field_to_match {
              + type = "URI"
            }
        }
    }

  # module.owasp_top_10.aws_waf_byte_match_set.xsswhitelist will be created
  + resource "aws_waf_byte_match_set" "xsswhitelist" {
      + id   = (known after apply)
      + name = (known after apply)
    }

  # module.owasp_top_10.aws_waf_rule.owasp_01_sql_injection_rule[0] will be created
  + resource "aws_waf_rule" "owasp_01_sql_injection_rule" {
      + id          = (known after apply)
      + metric_name = (known after apply)
      + name        = (known after apply)

      + predicates {
          + data_id = (known after apply)
          + negated = false
          + type    = "SqlInjectionMatch"
        }
    }

  # module.owasp_top_10.aws_waf_rule.owasp_02_auth_token_rule[0] will be created
  + resource "aws_waf_rule" "owasp_02_auth_token_rule" {
      + id          = (known after apply)
      + metric_name = (known after apply)
      + name        = (known after apply)

      + predicates {
          + data_id = (known after apply)
          + negated = false
          + type    = "ByteMatch"
        }
    }

  # module.owasp_top_10.aws_waf_rule.owasp_03_xss_rule[0] will be created
  + resource "aws_waf_rule" "owasp_03_xss_rule" {
      + id          = (known after apply)
      + metric_name = (known after apply)
      + name        = (known after apply)

      + predicates {
          + data_id = (known after apply)
          + negated = false
          + type    = "XssMatch"
        }
      + predicates {
          + data_id = (known after apply)
          + negated = true
          + type    = "ByteMatch"
        }
    }

  # module.owasp_top_10.aws_waf_rule.owasp_04_paths_rule[0] will be created
  + resource "aws_waf_rule" "owasp_04_paths_rule" {
      + id          = (known after apply)
      + metric_name = (known after apply)
      + name        = (known after apply)

      + predicates {
          + data_id = (known after apply)
          + negated = false
          + type    = "ByteMatch"
        }
    }

  # module.owasp_top_10.aws_waf_rule.owasp_06_php_insecure_rule[0] will be created
  + resource "aws_waf_rule" "owasp_06_php_insecure_rule" {
      + id          = (known after apply)
      + metric_name = (known after apply)
      + name        = (known after apply)

      + predicates {
          + data_id = (known after apply)
          + negated = false
          + type    = "ByteMatch"
        }
      + predicates {
          + data_id = (known after apply)
          + negated = false
          + type    = "ByteMatch"
        }
    }

  # module.owasp_top_10.aws_waf_rule.owasp_07_size_restriction_rule[0] will be created
  + resource "aws_waf_rule" "owasp_07_size_restriction_rule" {
      + id          = (known after apply)
      + metric_name = (known after apply)
      + name        = (known after apply)

      + predicates {
          + data_id = (known after apply)
          + negated = false
          + type    = "SizeConstraint"
        }
    }

  # module.owasp_top_10.aws_waf_rule.owasp_08_csrf_rule[0] will be created
  + resource "aws_waf_rule" "owasp_08_csrf_rule" {
      + id          = (known after apply)
      + metric_name = (known after apply)
      + name        = (known after apply)

      + predicates {
          + data_id = (known after apply)
          + negated = false
          + type    = "ByteMatch"
        }
      + predicates {
          + data_id = (known after apply)
          + negated = false
          + type    = "SizeConstraint"
        }
    }

  # module.owasp_top_10.aws_waf_rule.owasp_09_server_side_include_rule[0] will be created
  + resource "aws_waf_rule" "owasp_09_server_side_include_rule" {
      + id          = (known after apply)
      + metric_name = (known after apply)
      + name        = (known after apply)

      + predicates {
          + data_id = (known after apply)
          + negated = false
          + type    = "ByteMatch"
        }
    }

  # module.owasp_top_10.aws_waf_rule_group.owasp_top_10[0] will be created
  + resource "aws_waf_rule_group" "owasp_top_10" {
      + id          = (known after apply)
      + metric_name = (known after apply)
      + name        = (known after apply)

      + activated_rule {
          + priority = 1
          + rule_id  = (known after apply)
          + type     = "REGULAR"

          + action {
              + type = "BLOCK"
            }
        }
      + activated_rule {
          + priority = 2
          + rule_id  = (known after apply)
          + type     = "REGULAR"

          + action {
              + type = "BLOCK"
            }
        }
      + activated_rule {
          + priority = 3
          + rule_id  = (known after apply)
          + type     = "REGULAR"

          + action {
              + type = "BLOCK"
            }
        }
      + activated_rule {
          + priority = 4
          + rule_id  = (known after apply)
          + type     = "REGULAR"

          + action {
              + type = "BLOCK"
            }
        }
      + activated_rule {
          + priority = 5
          + rule_id  = (known after apply)
          + type     = "REGULAR"

          + action {
              + type = "BLOCK"
            }
        }
      + activated_rule {
          + priority = 6
          + rule_id  = (known after apply)
          + type     = "REGULAR"

          + action {
              + type = "BLOCK"
            }
        }
      + activated_rule {
          + priority = 7
          + rule_id  = (known after apply)
          + type     = "REGULAR"

          + action {
              + type = "BLOCK"
            }
        }
      + activated_rule {
          + priority = 8
          + rule_id  = (known after apply)
          + type     = "REGULAR"

          + action {
              + type = "BLOCK"
            }
        }
    }

  # module.owasp_top_10.aws_waf_size_constraint_set.owasp_07_size_restriction_set[0] will be created
  + resource "aws_waf_size_constraint_set" "owasp_07_size_restriction_set" {
      + id   = (known after apply)
      + name = (known after apply)

      + size_constraints {
          + comparison_operator = "GT"
          + size                = 4096
          + text_transformation = "NONE"

          + field_to_match {
              + type = "BODY"
            }
        }
      + size_constraints {
          + comparison_operator = "GT"
          + size                = 1024
          + text_transformation = "NONE"

          + field_to_match {
              + type = "QUERY_STRING"
            }
        }
      + size_constraints {
          + comparison_operator = "GT"
          + size                = 512
          + text_transformation = "NONE"

          + field_to_match {
              + type = "URI"
            }
        }
      + size_constraints {
          + comparison_operator = "GT"
          + size                = 4093
          + text_transformation = "NONE"

          + field_to_match {
              + data = "cookie"
              + type = "HEADER"
            }
        }
    }

  # module.owasp_top_10.aws_waf_size_constraint_set.owasp_08_csrf_token_size_constrain_set[0] will be created
  + resource "aws_waf_size_constraint_set" "owasp_08_csrf_token_size_constrain_set" {
      + id   = (known after apply)
      + name = (known after apply)

      + size_constraints {
          + comparison_operator = "EQ"
          + size                = 36
          + text_transformation = "NONE"

          + field_to_match {
              + data = "x-csrf-token"
              + type = "HEADER"
            }
        }
    }

  # module.owasp_top_10.aws_waf_sql_injection_match_set.owasp_01_sql_injection_set[0] will be created
  + resource "aws_waf_sql_injection_match_set" "owasp_01_sql_injection_set" {
      + id   = (known after apply)
      + name = (known after apply)

      + sql_injection_match_tuples {
          + text_transformation = "HTML_ENTITY_DECODE"

          + field_to_match {
              + type = "BODY"
            }
        }
      + sql_injection_match_tuples {
          + text_transformation = "URL_DECODE"

          + field_to_match {
              + type = "BODY"
            }
        }
      + sql_injection_match_tuples {
          + text_transformation = "HTML_ENTITY_DECODE"

          + field_to_match {
              + type = "QUERY_STRING"
            }
        }
      + sql_injection_match_tuples {
          + text_transformation = "URL_DECODE"

          + field_to_match {
              + type = "QUERY_STRING"
            }
        }
      + sql_injection_match_tuples {
          + text_transformation = "HTML_ENTITY_DECODE"

          + field_to_match {
              + type = "URI"
            }
        }
      + sql_injection_match_tuples {
          + text_transformation = "URL_DECODE"

          + field_to_match {
              + type = "URI"
            }
        }
      + sql_injection_match_tuples {
          + text_transformation = "HTML_ENTITY_DECODE"

          + field_to_match {
              + data = "Authorization"
              + type = "HEADER"
            }
        }
      + sql_injection_match_tuples {
          + text_transformation = "URL_DECODE"

          + field_to_match {
              + data = "Authorization"
              + type = "HEADER"
            }
        }
    }

  # module.owasp_top_10.aws_waf_xss_match_set.owasp_03_xss_set[0] will be created
  + resource "aws_waf_xss_match_set" "owasp_03_xss_set" {
      + id   = (known after apply)
      + name = (known after apply)

      + xss_match_tuples {
          + text_transformation = "HTML_ENTITY_DECODE"

          + field_to_match {
              + type = "BODY"
            }
        }
      + xss_match_tuples {
          + text_transformation = "URL_DECODE"

          + field_to_match {
              + type = "BODY"
            }
        }
      + xss_match_tuples {
          + text_transformation = "HTML_ENTITY_DECODE"

          + field_to_match {
              + type = "QUERY_STRING"
            }
        }
      + xss_match_tuples {
          + text_transformation = "URL_DECODE"

          + field_to_match {
              + type = "QUERY_STRING"
            }
        }
      + xss_match_tuples {
          + text_transformation = "HTML_ENTITY_DECODE"

          + field_to_match {
              + type = "URI"
            }
        }
      + xss_match_tuples {
          + text_transformation = "URL_DECODE"

          + field_to_match {
              + type = "URI"
            }
        }
      + xss_match_tuples {
          + text_transformation = "HTML_ENTITY_DECODE"

          + field_to_match {
              + data = "cookie"
              + type = "HEADER"
            }
        }
      + xss_match_tuples {
          + text_transformation = "URL_DECODE"

          + field_to_match {
              + data = "cookie"
              + type = "HEADER"
            }
        }
    }

  # module.owasp_top_10.random_id.this[0] will be created
  + resource "random_id" "this" {
      + b64         = (known after apply)
      + b64_std     = (known after apply)
      + b64_url     = (known after apply)
      + byte_length = 8
      + dec         = (known after apply)
      + hex         = (known after apply)
      + id          = (known after apply)
      + keepers     = {
          + "target_scope" = "global"
        }
    }

Plan: 21 to add, 0 to change, 0 to destroy.

------------------------------------------------------------------------

Note: You didn't specify an "-out" parameter to save this plan, so Terraform
can't guarantee that exactly these actions will be performed if
"terraform apply" is subsequently run.

<!---
Credit: 
This template is modified version of https://github.com/terraform-providers/terraform-provider-aws/blob/master/.github/PULL_REQUEST_TEMPLATE.md

Created: May 27, 2019 
Last updated: July 11, 2019
--->
