### PR TITLE
Updates to remove v0.12 Warnings + Adds ability to remove XSS rules

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -157,7 +157,7 @@ resource "aws_wafregional_xss_match_set" "owasp_03_xss_set" {
   name = "${lower(var.service_name)}-owasp-03-detect-xss-${random_id.this.0.hex}"
 
   dynamic "xss_match_tuple" {
-    for_each = var.disable_xss_uri_url_decode ? [] : [1]
+    for_each = var.disable_03_uri_url_decode ? [] : [1]
     content {
       text_transformation = "URL_DECODE"
 
@@ -168,7 +168,7 @@ resource "aws_wafregional_xss_match_set" "owasp_03_xss_set" {
   }
 
   dynamic "xss_match_tuple" {
-    for_each = var.disable_xss_uri_html_decode ? [] : [1]
+    for_each = var.disable_03_uri_html_decode ? [] : [1]
     content {
       text_transformation = "HTML_ENTITY_DECODE"
 
@@ -179,7 +179,7 @@ resource "aws_wafregional_xss_match_set" "owasp_03_xss_set" {
   }
 
   dynamic "xss_match_tuple" {
-    for_each = var.disable_xss_query_string_url_decode ? [] : [1]
+    for_each = var.disable_03_query_string_url_decode ? [] : [1]
     content {
       text_transformation = "URL_DECODE"
 
@@ -190,7 +190,7 @@ resource "aws_wafregional_xss_match_set" "owasp_03_xss_set" {
   }
 
   dynamic "xss_match_tuple" {
-    for_each = var.disable_xss_query_string_html_decode ? [] : [1]
+    for_each = var.disable_03_query_string_html_decode ? [] : [1]
     content {
       text_transformation = "HTML_ENTITY_DECODE"
 
@@ -201,7 +201,7 @@ resource "aws_wafregional_xss_match_set" "owasp_03_xss_set" {
   }
 
   dynamic "xss_match_tuple" {
-    for_each = var.disable_xss_body_url_decode ? [] : [1]
+    for_each = var.disable_03_body_url_decode ? [] : [1]
     content {
       text_transformation = "URL_DECODE"
 
@@ -212,7 +212,7 @@ resource "aws_wafregional_xss_match_set" "owasp_03_xss_set" {
   }
 
   dynamic "xss_match_tuple" {
-    for_each = var.disable_xss_body_html_decode ? [] : [1]
+    for_each = var.disable_03_body_html_decode ? [] : [1]
     content {
       text_transformation = "HTML_ENTITY_DECODE"
 
@@ -223,7 +223,7 @@ resource "aws_wafregional_xss_match_set" "owasp_03_xss_set" {
   }
 
   dynamic "xss_match_tuple" {
-    for_each = var.disable_xss_cookie_url_decode ? [] : [1]
+    for_each = var.disable_03_cookie_url_decode ? [] : [1]
     content {
       text_transformation = "URL_DECODE"
 
@@ -235,7 +235,7 @@ resource "aws_wafregional_xss_match_set" "owasp_03_xss_set" {
   }
 
   dynamic "xss_match_tuple" {
-    for_each = var.disable_xss_cookie_html_decode ? [] : [1]
+    for_each = var.disable_03_cookie_html_decode ? [] : [1]
     content {
       text_transformation = "HTML_ENTITY_DECODE"
 

--- a/main.tf
+++ b/main.tf
@@ -1393,11 +1393,11 @@ resource "aws_waf_size_constraint_set" "owasp_08_csrf_token_size_constrain_set" 
   size_constraints {
     text_transformation = "NONE"
     comparison_operator = "EQ"
-    size                = "${var.csrf_expected_size}"
+    size                = var.csrf_expected_size
 
     field_to_match {
       type = "HEADER"
-      data = "${var.csrf_expected_header}"
+      data = var.csrf_expected_header
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -156,69 +156,93 @@ resource "aws_wafregional_xss_match_set" "owasp_03_xss_set" {
 
   name = "${lower(var.service_name)}-owasp-03-detect-xss-${random_id.this.0.hex}"
 
-  xss_match_tuple {
-    text_transformation = "URL_DECODE"
+  dynamic "xss_match_tuple" {
+    for_each = var.disable_xss_uri_url_decode ? [] : [1]
+    content {
+      text_transformation = "URL_DECODE"
 
-    field_to_match {
-      type = "URI"
+      field_to_match {
+        type = "URI"
+      }
     }
   }
 
-  xss_match_tuple {
-    text_transformation = "HTML_ENTITY_DECODE"
+  dynamic "xss_match_tuple" {
+    for_each = var.disable_xss_uri_html_decode ? [] : [1]
+    content {
+      text_transformation = "HTML_ENTITY_DECODE"
 
-    field_to_match {
-      type = "URI"
+      field_to_match {
+        type = "URI"
+      }
     }
   }
 
-  xss_match_tuple {
-    text_transformation = "URL_DECODE"
+  dynamic "xss_match_tuple" {
+    for_each = var.disable_xss_query_string_url_decode ? [] : [1]
+    content {
+      text_transformation = "URL_DECODE"
 
-    field_to_match {
-      type = "QUERY_STRING"
+      field_to_match {
+        type = "QUERY_STRING"
+      }
     }
   }
 
-  xss_match_tuple {
-    text_transformation = "HTML_ENTITY_DECODE"
+  dynamic "xss_match_tuple" {
+    for_each = var.disable_xss_query_string_html_decode ? [] : [1]
+    content {
+      text_transformation = "HTML_ENTITY_DECODE"
 
-    field_to_match {
-      type = "QUERY_STRING"
+      field_to_match {
+        type = "QUERY_STRING"
+      }
     }
   }
 
-  xss_match_tuple {
-    text_transformation = "URL_DECODE"
+  dynamic "xss_match_tuple" {
+    for_each = var.disable_xss_body_url_decode ? [] : [1]
+    content {
+      text_transformation = "URL_DECODE"
 
-    field_to_match {
-      type = "BODY"
+      field_to_match {
+        type = "BODY"
+      }
     }
   }
 
-  xss_match_tuple {
-    text_transformation = "HTML_ENTITY_DECODE"
+  dynamic "xss_match_tuple" {
+    for_each = var.disable_xss_body_html_decode ? [] : [1]
+    content {
+      text_transformation = "HTML_ENTITY_DECODE"
 
-    field_to_match {
-      type = "BODY"
+      field_to_match {
+        type = "BODY"
+      }
     }
   }
 
-  xss_match_tuple {
-    text_transformation = "URL_DECODE"
+  dynamic "xss_match_tuple" {
+    for_each = var.disable_xss_cookie_url_decode ? [] : [1]
+    content {
+      text_transformation = "URL_DECODE"
 
-    field_to_match {
-      type = "HEADER"
-      data = "cookie"
+      field_to_match {
+        type = "HEADER"
+        data = "cookie"
+      }
     }
   }
 
-  xss_match_tuple {
-    text_transformation = "HTML_ENTITY_DECODE"
+  dynamic "xss_match_tuple" {
+    for_each = var.disable_xss_cookie_html_decode ? [] : [1]
+    content {
+      text_transformation = "HTML_ENTITY_DECODE"
 
-    field_to_match {
-      type = "HEADER"
-      data = "cookie"
+      field_to_match {
+        type = "HEADER"
+        data = "cookie"
+      }
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -907,15 +907,13 @@ resource "aws_waf_sql_injection_match_set" "owasp_01_sql_injection_set" {
 }
 
 resource "aws_waf_rule" "owasp_01_sql_injection_rule" {
-  depends_on = ["aws_waf_sql_injection_match_set.owasp_01_sql_injection_set"]
-
   count = lower(var.target_scope) == "global" ? 1 : 0
 
   name        = "${lower(var.service_name)}-owasp-01-mitigate-sql-injection-${random_id.this.0.hex}"
   metric_name = "${lower(var.service_name)}OWASP01MitigateSQLInjection${random_id.this.0.hex}"
 
   predicates {
-    data_id = "${aws_waf_sql_injection_match_set.owasp_01_sql_injection_set.0.id}"
+    data_id = aws_waf_sql_injection_match_set.owasp_01_sql_injection_set.0.id
     negated = "false"
     type    = "SqlInjectionMatch"
   }

--- a/main.tf
+++ b/main.tf
@@ -88,7 +88,7 @@ resource "aws_wafregional_sql_injection_match_set" "owasp_01_sql_injection_set" 
 }
 
 resource "aws_wafregional_rule" "owasp_01_sql_injection_rule" {
-  depends_on = [ aws_wafregional_sql_injection_match_set.owasp_01_sql_injection_set ]
+  depends_on = [aws_wafregional_sql_injection_match_set.owasp_01_sql_injection_set]
 
   count = lower(var.target_scope) == "regional" ? 1 : 0
 
@@ -1063,83 +1063,107 @@ resource "aws_waf_byte_match_set" "owasp_04_paths_string_set" {
 
   name = "${lower(var.service_name)}-owasp-04-match-rfi-lfi-traversal-${random_id.this.0.hex}"
 
-  byte_match_tuples {
-    text_transformation   = "URL_DECODE"
-    target_string         = "../"
-    positional_constraint = "CONTAINS"
+  dynamic "byte_match_tuples" {
+    for_each = var.disable_04_uri_contains_previous_dir_after_url_decode ? [] : [1]
+    content {
+      text_transformation   = "URL_DECODE"
+      target_string         = "../"
+      positional_constraint = "CONTAINS"
 
-    field_to_match {
-      type = "URI"
+      field_to_match {
+        type = "URI"
+      }
     }
   }
 
-  byte_match_tuples {
-    text_transformation   = "HTML_ENTITY_DECODE"
-    target_string         = "../"
-    positional_constraint = "CONTAINS"
+  dynamic "byte_match_tuples" {
+    for_each = var.disable_04_uri_contains_previous_dir_after_html_decode ? [] : [1]
+    content {
+      text_transformation   = "HTML_ENTITY_DECODE"
+      target_string         = "../"
+      positional_constraint = "CONTAINS"
 
-    field_to_match {
-      type = "URI"
+      field_to_match {
+        type = "URI"
+      }
     }
   }
 
-  byte_match_tuples {
-    text_transformation   = "URL_DECODE"
-    target_string         = "../"
-    positional_constraint = "CONTAINS"
+  dynamic "byte_match_tuples" {
+    for_each = var.disable_04_query_string_contains_previous_dir_after_url_decode ? [] : [1]
+    content {
+      text_transformation   = "URL_DECODE"
+      target_string         = "../"
+      positional_constraint = "CONTAINS"
 
-    field_to_match {
-      type = "QUERY_STRING"
+      field_to_match {
+        type = "QUERY_STRING"
+      }
     }
   }
 
-  byte_match_tuples {
-    text_transformation   = "HTML_ENTITY_DECODE"
-    target_string         = "../"
-    positional_constraint = "CONTAINS"
+  dynamic "byte_match_tuples" {
+    for_each = var.disable_04_query_string_contains_previous_dir_after_html_decode ? [] : [1]
+    content {
+      text_transformation   = "HTML_ENTITY_DECODE"
+      target_string         = "../"
+      positional_constraint = "CONTAINS"
 
-    field_to_match {
-      type = "QUERY_STRING"
+      field_to_match {
+        type = "QUERY_STRING"
+      }
     }
   }
 
-  byte_match_tuples {
-    text_transformation   = "URL_DECODE"
-    target_string         = "://"
-    positional_constraint = "CONTAINS"
+  dynamic "byte_match_tuples" {
+    for_each = var.disable_04_uri_contains_url_path_after_url_decode ? [] : [1]
+    content {
+      text_transformation   = "URL_DECODE"
+      target_string         = "://"
+      positional_constraint = "CONTAINS"
 
-    field_to_match {
-      type = "URI"
+      field_to_match {
+        type = "URI"
+      }
     }
   }
 
-  byte_match_tuples {
-    text_transformation   = "HTML_ENTITY_DECODE"
-    target_string         = "://"
-    positional_constraint = "CONTAINS"
+  dynamic "byte_match_tuples" {
+    for_each = var.disable_04_uri_contains_url_path_after_html_decode ? [] : [1]
+    content {
+      text_transformation   = "HTML_ENTITY_DECODE"
+      target_string         = "://"
+      positional_constraint = "CONTAINS"
 
-    field_to_match {
-      type = "URI"
+      field_to_match {
+        type = "URI"
+      }
     }
   }
 
-  byte_match_tuples {
-    text_transformation   = "URL_DECODE"
-    target_string         = "://"
-    positional_constraint = "CONTAINS"
+  dynamic "byte_match_tuples" {
+    for_each = var.disable_04_query_string_contains_url_path_after_url_decode ? [] : [1]
+    content {
+      text_transformation   = "URL_DECODE"
+      target_string         = "://"
+      positional_constraint = "CONTAINS"
 
-    field_to_match {
-      type = "QUERY_STRING"
+      field_to_match {
+        type = "QUERY_STRING"
+      }
     }
   }
 
-  byte_match_tuples {
-    text_transformation   = "HTML_ENTITY_DECODE"
-    target_string         = "://"
-    positional_constraint = "CONTAINS"
+  dynamic "byte_match_tuples" {
+    for_each = var.disable_04_query_string_contains_url_path_after_html_decode ? [] : [1]
+    content {
+      text_transformation   = "HTML_ENTITY_DECODE"
+      target_string         = "://"
+      positional_constraint = "CONTAINS"
 
-    field_to_match {
-      type = "QUERY_STRING"
+      field_to_match {
+        type = "QUERY_STRING"
+      }
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,12 +1,12 @@
 # Random ID Generator
 
 resource "random_id" "this" {
-  count = "${lower(var.target_scope) == "regional" || lower(var.target_scope) == "global" ? "1" : "0"}"
+  count = lower(var.target_scope) == "regional" || lower(var.target_scope) == "global" ? 1 : 0
 
   byte_length = "8"
 
   keepers = {
-    target_scope = "${lower(var.target_scope)}"
+    target_scope = lower(var.target_scope)
   }
 }
 
@@ -16,7 +16,7 @@ resource "random_id" "this" {
 ### Mitigate SQL Injection Attacks
 ### Matches attempted SQLi patterns in the URI, QUERY_STRING, BODY, COOKIES
 resource "aws_wafregional_sql_injection_match_set" "owasp_01_sql_injection_set" {
-  count = "${lower(var.target_scope) == "regional" ? "1" : "0"}"
+  count = lower(var.target_scope) == "regional" ? 1 : 0
 
   name = "${lower(var.service_name)}-owasp-01-detect-sql-injection-${random_id.this.0.hex}"
 
@@ -88,15 +88,15 @@ resource "aws_wafregional_sql_injection_match_set" "owasp_01_sql_injection_set" 
 }
 
 resource "aws_wafregional_rule" "owasp_01_sql_injection_rule" {
-  depends_on = ["aws_wafregional_sql_injection_match_set.owasp_01_sql_injection_set"]
+  depends_on = [ aws_wafregional_sql_injection_match_set.owasp_01_sql_injection_set ]
 
-  count = "${lower(var.target_scope) == "regional" ? "1" : "0"}"
+  count = lower(var.target_scope) == "regional" ? 1 : 0
 
   name        = "${lower(var.service_name)}-owasp-01-mitigate-sql-injection-${random_id.this.0.hex}"
   metric_name = "${lower(var.service_name)}OWASP01MitigateSQLInjection${random_id.this.0.hex}"
 
   predicate {
-    data_id = "${aws_wafregional_sql_injection_match_set.owasp_01_sql_injection_set.0.id}"
+    data_id = aws_wafregional_sql_injection_match_set.owasp_01_sql_injection_set.0.id
     negated = "false"
     type    = "SqlInjectionMatch"
   }
@@ -106,7 +106,7 @@ resource "aws_wafregional_rule" "owasp_01_sql_injection_rule" {
 ### Blacklist bad/hijacked JWT tokens or session IDs
 ### Matches the specific values in the cookie or Authorization header for JWT it is sufficient to check the signature
 resource "aws_wafregional_byte_match_set" "owasp_02_auth_token_string_set" {
-  count = "${lower(var.target_scope) == "regional" ? "1" : "0"}"
+  count = lower(var.target_scope) == "regional" ? 1 : 0
 
   name = "${lower(var.service_name)}-owasp-02-match-auth-token-${random_id.this.0.hex}"
 
@@ -136,13 +136,13 @@ resource "aws_wafregional_byte_match_set" "owasp_02_auth_token_string_set" {
 resource "aws_wafregional_rule" "owasp_02_auth_token_rule" {
   depends_on = ["aws_wafregional_byte_match_set.owasp_02_auth_token_string_set"]
 
-  count = "${lower(var.target_scope) == "regional" ? "1" : "0"}"
+  count = lower(var.target_scope) == "regional" ? 1 : 0
 
   name        = "${lower(var.service_name)}-owasp-02-detect-bad-auth-token-${random_id.this.0.hex}"
   metric_name = "${lower(var.service_name)}OWASP02BadAuthToken${random_id.this.0.hex}"
 
   predicate {
-    data_id = "${aws_wafregional_byte_match_set.owasp_02_auth_token_string_set.0.id}"
+    data_id = aws_wafregional_byte_match_set.owasp_02_auth_token_string_set.0.id
     negated = "false"
     type    = "ByteMatch"
   }
@@ -152,7 +152,7 @@ resource "aws_wafregional_rule" "owasp_02_auth_token_rule" {
 ### Mitigate Cross Site Scripting Attacks
 ### Matches attempted XSS patterns in the URI, QUERY_STRING, BODY, COOKIES
 resource "aws_wafregional_xss_match_set" "owasp_03_xss_set" {
-  count = "${lower(var.target_scope) == "regional" ? "1" : "0"}"
+  count = lower(var.target_scope) == "regional" ? 1 : 0
 
   name = "${lower(var.service_name)}-owasp-03-detect-xss-${random_id.this.0.hex}"
 
@@ -250,7 +250,7 @@ resource "aws_wafregional_xss_match_set" "owasp_03_xss_set" {
 resource "aws_wafregional_rule" "owasp_03_xss_rule" {
   depends_on = ["aws_wafregional_xss_match_set.owasp_03_xss_set"]
 
-  count = "${lower(var.target_scope) == "regional" ? "1" : "0"}"
+  count = lower(var.target_scope) == "regional" ? 1 : 0
 
   name        = "${lower(var.service_name)}-owasp-03-mitigate-xss-${random_id.this.0.hex}"
   metric_name = "${lower(var.service_name)}OWASP03MitigateXSS${random_id.this.0.hex}"
@@ -266,7 +266,7 @@ resource "aws_wafregional_rule" "owasp_03_xss_rule" {
 ### Path Traversal, LFI, RFI
 ### Matches request patterns designed to traverse filesystem paths, and include local or remote files
 resource "aws_wafregional_byte_match_set" "owasp_04_paths_string_set" {
-  count = "${lower(var.target_scope) == "regional" ? "1" : "0"}"
+  count = lower(var.target_scope) == "regional" ? 1 : 0
 
   name = "${lower(var.service_name)}-owasp-04-match-rfi-lfi-traversal-${random_id.this.0.hex}"
 
@@ -354,7 +354,7 @@ resource "aws_wafregional_byte_match_set" "owasp_04_paths_string_set" {
 resource "aws_wafregional_rule" "owasp_04_paths_rule" {
   depends_on = ["aws_wafregional_byte_match_set.owasp_04_paths_string_set"]
 
-  count = "${lower(var.target_scope) == "regional" ? "1" : "0"}"
+  count = lower(var.target_scope) == "regional" ? 1 : 0
 
   name        = "${lower(var.service_name)}-owasp-04-detect-rfi-lfi-traversal-${random_id.this.0.hex}"
   metric_name = "${lower(var.service_name)}OWASP04DetectRFILFITraversal${random_id.this.0.hex}"
@@ -376,7 +376,7 @@ resource "aws_wafregional_rule" "owasp_04_paths_rule" {
 ## PHP Specific Security Misconfigurations
 ## Matches request patterns designed to exploit insecure PHP/CGI configuration
 resource "aws_wafregional_byte_match_set" "owasp_06_php_insecure_qs_string_set" {
-  count = "${lower(var.target_scope) == "regional" ? "1" : "0"}"
+  count = lower(var.target_scope) == "regional" ? 1 : 0
 
   name = "${lower(var.service_name)}-owasp-06-match-php-insecure-var-refs-${random_id.this.0.hex}"
 
@@ -462,7 +462,7 @@ resource "aws_wafregional_byte_match_set" "owasp_06_php_insecure_qs_string_set" 
 }
 
 resource "aws_wafregional_byte_match_set" "owasp_06_php_insecure_uri_string_set" {
-  count = "${lower(var.target_scope) == "regional" ? "1" : "0"}"
+  count = lower(var.target_scope) == "regional" ? 1 : 0
 
   name = "${lower(var.service_name)}-owasp-06-match-php-insecure-uri-${random_id.this.0.hex}"
 
@@ -490,7 +490,7 @@ resource "aws_wafregional_byte_match_set" "owasp_06_php_insecure_uri_string_set"
 resource "aws_wafregional_rule" "owasp_06_php_insecure_rule" {
   depends_on = ["aws_wafregional_byte_match_set.owasp_06_php_insecure_qs_string_set", "aws_wafregional_byte_match_set.owasp_06_php_insecure_uri_string_set"]
 
-  count = "${lower(var.target_scope) == "regional" ? "1" : "0"}"
+  count = lower(var.target_scope) == "regional" ? 1 : 0
 
   name        = "${lower(var.service_name)}-owasp-06-detect-php-insecure-${random_id.this.0.hex}"
   metric_name = "${lower(var.service_name)}OWASP06DetectPHPInsecure${random_id.this.0.hex}"
@@ -512,14 +512,14 @@ resource "aws_wafregional_rule" "owasp_06_php_insecure_rule" {
 ### Mitigate abnormal requests via size restrictions
 ### Enforce consistent request hygene, limit size of key elements
 resource "aws_wafregional_size_constraint_set" "owasp_07_size_restriction_set" {
-  count = "${lower(var.target_scope) == "regional" ? "1" : "0"}"
+  count = lower(var.target_scope) == "regional" ? 1 : 0
 
   name = "${lower(var.service_name)}-owasp-07-size-restrictions-${random_id.this.0.hex}"
 
   size_constraints {
     text_transformation = "NONE"
     comparison_operator = "GT"
-    size                = "${var.max_expected_uri_size}"
+    size                = var.max_expected_uri_size
 
     field_to_match {
       type = "URI"
@@ -529,7 +529,7 @@ resource "aws_wafregional_size_constraint_set" "owasp_07_size_restriction_set" {
   size_constraints {
     text_transformation = "NONE"
     comparison_operator = "GT"
-    size                = "${var.max_expected_query_string_size}"
+    size                = var.max_expected_query_string_size
 
     field_to_match {
       type = "QUERY_STRING"
@@ -539,7 +539,7 @@ resource "aws_wafregional_size_constraint_set" "owasp_07_size_restriction_set" {
   size_constraints {
     text_transformation = "NONE"
     comparison_operator = "GT"
-    size                = "${var.max_expected_body_size}"
+    size                = var.max_expected_body_size
 
     field_to_match {
       type = "BODY"
@@ -549,7 +549,7 @@ resource "aws_wafregional_size_constraint_set" "owasp_07_size_restriction_set" {
   size_constraints {
     text_transformation = "NONE"
     comparison_operator = "GT"
-    size                = "${var.max_expected_cookie_size}"
+    size                = var.max_expected_cookie_size
 
     field_to_match {
       type = "HEADER"
@@ -561,13 +561,13 @@ resource "aws_wafregional_size_constraint_set" "owasp_07_size_restriction_set" {
 resource "aws_wafregional_rule" "owasp_07_size_restriction_rule" {
   depends_on = ["aws_wafregional_size_constraint_set.owasp_07_size_restriction_set"]
 
-  count = "${lower(var.target_scope) == "regional" ? "1" : "0"}"
+  count = lower(var.target_scope) == "regional" ? 1 : 0
 
   name        = "${lower(var.service_name)}-owasp-07-restrict-sizes-${random_id.this.0.hex}"
   metric_name = "${lower(var.service_name)}OWASP07RestrictSizes${random_id.this.0.hex}"
 
   predicate {
-    data_id = "${aws_wafregional_size_constraint_set.owasp_07_size_restriction_set.0.id}"
+    data_id = aws_wafregional_size_constraint_set.owasp_07_size_restriction_set.0.id
     negated = "false"
     type    = "SizeConstraint"
   }
@@ -577,7 +577,7 @@ resource "aws_wafregional_rule" "owasp_07_size_restriction_rule" {
 ### CSRF token enforcement example
 ### Enforce the presence of CSRF token in request header
 resource "aws_wafregional_byte_match_set" "owasp_08_csrf_method_string_set" {
-  count = "${lower(var.target_scope) == "regional" ? "1" : "0"}"
+  count = lower(var.target_scope) == "regional" ? 1 : 0
 
   name = "${lower(var.service_name)}-owasp-08-match-csrf-method-${random_id.this.0.hex}"
 
@@ -593,18 +593,18 @@ resource "aws_wafregional_byte_match_set" "owasp_08_csrf_method_string_set" {
 }
 
 resource "aws_wafregional_size_constraint_set" "owasp_08_csrf_token_size_constrain_set" {
-  count = "${lower(var.target_scope) == "regional" ? "1" : "0"}"
+  count = lower(var.target_scope) == "regional" ? 1 : 0
 
   name = "${lower(var.service_name)}-owasp-08-csrf-token-size-${random_id.this.0.hex}"
 
   size_constraints {
     text_transformation = "NONE"
     comparison_operator = "EQ"
-    size                = "${var.csrf_expected_size}"
+    size                = var.csrf_expected_size
 
     field_to_match {
       type = "HEADER"
-      data = "${var.csrf_expected_header}"
+      data = var.csrf_expected_header
     }
   }
 }
@@ -612,7 +612,7 @@ resource "aws_wafregional_size_constraint_set" "owasp_08_csrf_token_size_constra
 resource "aws_wafregional_rule" "owasp_08_csrf_rule" {
   depends_on = ["aws_wafregional_byte_match_set.owasp_08_csrf_method_string_set", "aws_wafregional_size_constraint_set.owasp_08_csrf_token_size_constrain_set"]
 
-  count = "${lower(var.target_scope) == "regional" ? "1" : "0"}"
+  count = lower(var.target_scope) == "regional" ? 1 : 0
 
   name        = "${lower(var.service_name)}-owasp-08-enforce-csrf-${random_id.this.0.hex}"
   metric_name = "${lower(var.service_name)}OWASP08EnforceCSRF${random_id.this.0.hex}"
@@ -624,7 +624,7 @@ resource "aws_wafregional_rule" "owasp_08_csrf_rule" {
   }
 
   predicate {
-    data_id = "${aws_wafregional_size_constraint_set.owasp_08_csrf_token_size_constrain_set.0.id}"
+    data_id = aws_wafregional_size_constraint_set.owasp_08_csrf_token_size_constrain_set.0.id
     negated = "false"
     type    = "SizeConstraint"
   }
@@ -634,7 +634,7 @@ resource "aws_wafregional_rule" "owasp_08_csrf_rule" {
 ### Server-side includes & libraries in webroot
 ### Matches request patterns for webroot objects that shouldn't be directly accessible
 resource "aws_wafregional_byte_match_set" "owasp_09_server_side_include_string_set" {
-  count = "${lower(var.target_scope) == "regional" ? "1" : "0"}"
+  count = lower(var.target_scope) == "regional" ? 1 : 0
 
   name = "${lower(var.service_name)}-owasp-09-match-ssi-${random_id.this.0.hex}"
 
@@ -712,13 +712,13 @@ resource "aws_wafregional_byte_match_set" "owasp_09_server_side_include_string_s
 resource "aws_wafregional_rule" "owasp_09_server_side_include_rule" {
   depends_on = ["aws_wafregional_byte_match_set.owasp_09_server_side_include_string_set"]
 
-  count = "${lower(var.target_scope) == "regional" ? "1" : "0"}"
+  count = lower(var.target_scope) == "regional" ? 1 : 0
 
   name        = "${lower(var.service_name)}-owasp-09-detect-ssi-${random_id.this.0.hex}"
   metric_name = "${lower(var.service_name)}OWASP09DetectSSI${random_id.this.0.hex}"
 
   predicate {
-    data_id = "${aws_wafregional_byte_match_set.owasp_09_server_side_include_string_set.0.id}"
+    data_id = aws_wafregional_byte_match_set.owasp_09_server_side_include_string_set.0.id
     negated = "false"
     type    = "ByteMatch"
   }
@@ -743,10 +743,10 @@ resource "aws_wafregional_rule_group" "owasp_top_10" {
     "aws_wafregional_rule.owasp_09_server_side_include_rule",
   ]
 
-  count = "${lower(var.create_rule_group) && lower(var.target_scope) == "regional" ? "1" : "0"}"
+  count = lower(var.create_rule_group) && lower(var.target_scope) == "regional" ? 1 : 0
 
-  name        = "${format("%s-owasp-top-10-%s", lower(var.service_name), random_id.this.0.hex)}"
-  metric_name = "${format("%sOWASPTop10%s", lower(var.service_name), random_id.this.0.hex)}"
+  name        = format("%s-owasp-top-10-%s", lower(var.service_name), random_id.this.0.hex)
+  metric_name = format("%sOWASPTop10%s", lower(var.service_name), random_id.this.0.hex)
 
   activated_rule {
     action {
@@ -754,7 +754,7 @@ resource "aws_wafregional_rule_group" "owasp_top_10" {
     }
 
     priority = "1"
-    rule_id  = "${aws_wafregional_rule.owasp_07_size_restriction_rule.0.id}"
+    rule_id  = aws_wafregional_rule.owasp_07_size_restriction_rule.0.id
     type     = "REGULAR"
   }
 
@@ -764,7 +764,7 @@ resource "aws_wafregional_rule_group" "owasp_top_10" {
     }
 
     priority = "2"
-    rule_id  = "${aws_wafregional_rule.owasp_02_auth_token_rule.0.id}"
+    rule_id  = aws_wafregional_rule.owasp_02_auth_token_rule.0.id
     type     = "REGULAR"
   }
 
@@ -774,7 +774,7 @@ resource "aws_wafregional_rule_group" "owasp_top_10" {
     }
 
     priority = "3"
-    rule_id  = "${aws_wafregional_rule.owasp_01_sql_injection_rule.0.id}"
+    rule_id  = aws_wafregional_rule.owasp_01_sql_injection_rule.0.id
     type     = "REGULAR"
   }
 
@@ -784,7 +784,7 @@ resource "aws_wafregional_rule_group" "owasp_top_10" {
     }
 
     priority = "4"
-    rule_id  = "${aws_wafregional_rule.owasp_03_xss_rule.0.id}"
+    rule_id  = aws_wafregional_rule.owasp_03_xss_rule.0.id
     type     = "REGULAR"
   }
 
@@ -794,7 +794,7 @@ resource "aws_wafregional_rule_group" "owasp_top_10" {
     }
 
     priority = "5"
-    rule_id  = "${aws_wafregional_rule.owasp_04_paths_rule.0.id}"
+    rule_id  = aws_wafregional_rule.owasp_04_paths_rule.0.id
     type     = "REGULAR"
   }
 
@@ -804,7 +804,7 @@ resource "aws_wafregional_rule_group" "owasp_top_10" {
     }
 
     priority = "6"
-    rule_id  = "${aws_wafregional_rule.owasp_06_php_insecure_rule.0.id}"
+    rule_id  = aws_wafregional_rule.owasp_06_php_insecure_rule.0.id
     type     = "REGULAR"
   }
 
@@ -814,7 +814,7 @@ resource "aws_wafregional_rule_group" "owasp_top_10" {
     }
 
     priority = "7"
-    rule_id  = "${aws_wafregional_rule.owasp_08_csrf_rule.0.id}"
+    rule_id  = aws_wafregional_rule.owasp_08_csrf_rule.0.id
     type     = "REGULAR"
   }
 
@@ -824,7 +824,7 @@ resource "aws_wafregional_rule_group" "owasp_top_10" {
     }
 
     priority = "8"
-    rule_id  = "${aws_wafregional_rule.owasp_09_server_side_include_rule.0.id}"
+    rule_id  = aws_wafregional_rule.owasp_09_server_side_include_rule.0.id
     type     = "REGULAR"
   }
 }
@@ -835,7 +835,7 @@ resource "aws_wafregional_rule_group" "owasp_top_10" {
 ### Mitigate SQL Injection Attacks
 ### Matches attempted SQLi patterns in the URI, QUERY_STRING, BODY, COOKIES
 resource "aws_waf_sql_injection_match_set" "owasp_01_sql_injection_set" {
-  count = "${lower(var.target_scope) == "global" ? "1" : "0"}"
+  count = lower(var.target_scope) == "global" ? 1 : 0
 
   name = "${lower(var.service_name)}-owasp-01-detect-sql-injection-${random_id.this.0.hex}"
 
@@ -909,7 +909,7 @@ resource "aws_waf_sql_injection_match_set" "owasp_01_sql_injection_set" {
 resource "aws_waf_rule" "owasp_01_sql_injection_rule" {
   depends_on = ["aws_waf_sql_injection_match_set.owasp_01_sql_injection_set"]
 
-  count = "${lower(var.target_scope) == "global" ? "1" : "0"}"
+  count = lower(var.target_scope) == "global" ? 1 : 0
 
   name        = "${lower(var.service_name)}-owasp-01-mitigate-sql-injection-${random_id.this.0.hex}"
   metric_name = "${lower(var.service_name)}OWASP01MitigateSQLInjection${random_id.this.0.hex}"
@@ -925,7 +925,7 @@ resource "aws_waf_rule" "owasp_01_sql_injection_rule" {
 ### Blacklist bad/hijacked JWT tokens or session IDs
 ### Matches the specific values in the cookie or Authorization header for JWT it is sufficient to check the signature
 resource "aws_waf_byte_match_set" "owasp_02_auth_token_string_set" {
-  count = "${lower(var.target_scope) == "global" ? "1" : "0"}"
+  count = lower(var.target_scope) == "global" ? 1 : 0
 
   name = "${lower(var.service_name)}-owasp-02-match-auth-token-${random_id.this.0.hex}"
 
@@ -955,7 +955,7 @@ resource "aws_waf_byte_match_set" "owasp_02_auth_token_string_set" {
 resource "aws_waf_rule" "owasp_02_auth_token_rule" {
   depends_on = ["aws_waf_byte_match_set.owasp_02_auth_token_string_set"]
 
-  count = "${lower(var.target_scope) == "global" ? "1" : "0"}"
+  count = lower(var.target_scope) == "global" ? 1 : 0
 
   name        = "${lower(var.service_name)}-owasp-02-detect-bad-auth-token-${random_id.this.0.hex}"
   metric_name = "${lower(var.service_name)}OWASP02BadAuthToken${random_id.this.0.hex}"
@@ -971,7 +971,7 @@ resource "aws_waf_rule" "owasp_02_auth_token_rule" {
 ### Mitigate Cross Site Scripting Attacks
 ### Matches attempted XSS patterns in the URI, QUERY_STRING, BODY, COOKIES
 resource "aws_waf_xss_match_set" "owasp_03_xss_set" {
-  count = "${lower(var.target_scope) == "global" ? "1" : "0"}"
+  count = lower(var.target_scope) == "global" ? 1 : 0
 
   name = "${lower(var.service_name)}-owasp-03-detect-xss-${random_id.this.0.hex}"
 
@@ -1045,7 +1045,7 @@ resource "aws_waf_xss_match_set" "owasp_03_xss_set" {
 resource "aws_waf_rule" "owasp_03_xss_rule" {
   depends_on = ["aws_waf_xss_match_set.owasp_03_xss_set"]
 
-  count = "${lower(var.target_scope) == "global" ? "1" : "0"}"
+  count = lower(var.target_scope) == "global" ? 1 : 0
 
   name        = "${lower(var.service_name)}-owasp-03-mitigate-xss-${random_id.this.0.hex}"
   metric_name = "${lower(var.service_name)}OWASP03MitigateXSS${random_id.this.0.hex}"
@@ -1061,7 +1061,7 @@ resource "aws_waf_rule" "owasp_03_xss_rule" {
 ### Path Traversal, LFI, RFI
 ### Matches request patterns designed to traverse filesystem paths, and include local or remote files
 resource "aws_waf_byte_match_set" "owasp_04_paths_string_set" {
-  count = "${lower(var.target_scope) == "global" ? "1" : "0"}"
+  count = lower(var.target_scope) == "global" ? 1 : 0
 
   name = "${lower(var.service_name)}-owasp-04-match-rfi-lfi-traversal-${random_id.this.0.hex}"
 
@@ -1149,7 +1149,7 @@ resource "aws_waf_byte_match_set" "owasp_04_paths_string_set" {
 resource "aws_waf_rule" "owasp_04_paths_rule" {
   depends_on = ["aws_waf_byte_match_set.owasp_04_paths_string_set"]
 
-  count = "${lower(var.target_scope) == "global" ? "1" : "0"}"
+  count = lower(var.target_scope) == "global" ? 1 : 0
 
   name        = "${lower(var.service_name)}-owasp-04-detect-rfi-lfi-traversal-${random_id.this.0.hex}"
   metric_name = "${lower(var.service_name)}OWASP04DetectRFILFITraversal${random_id.this.0.hex}"
@@ -1171,7 +1171,7 @@ resource "aws_waf_rule" "owasp_04_paths_rule" {
 ## PHP Specific Security Misconfigurations
 ## Matches request patterns designed to exploit insecure PHP/CGI configuration
 resource "aws_waf_byte_match_set" "owasp_06_php_insecure_qs_string_set" {
-  count = "${lower(var.target_scope) == "global" ? "1" : "0"}"
+  count = lower(var.target_scope) == "global" ? 1 : 0
 
   name = "${lower(var.service_name)}-owasp-06-match-php-insecure-var-refs-${random_id.this.0.hex}"
 
@@ -1257,7 +1257,7 @@ resource "aws_waf_byte_match_set" "owasp_06_php_insecure_qs_string_set" {
 }
 
 resource "aws_waf_byte_match_set" "owasp_06_php_insecure_uri_string_set" {
-  count = "${lower(var.target_scope) == "global" ? "1" : "0"}"
+  count = lower(var.target_scope) == "global" ? 1 : 0
 
   name = "${lower(var.service_name)}-owasp-06-match-php-insecure-uri-${random_id.this.0.hex}"
 
@@ -1285,7 +1285,7 @@ resource "aws_waf_byte_match_set" "owasp_06_php_insecure_uri_string_set" {
 resource "aws_waf_rule" "owasp_06_php_insecure_rule" {
   depends_on = ["aws_waf_byte_match_set.owasp_06_php_insecure_qs_string_set", "aws_waf_byte_match_set.owasp_06_php_insecure_uri_string_set"]
 
-  count = "${lower(var.target_scope) == "global" ? "1" : "0"}"
+  count = lower(var.target_scope) == "global" ? 1 : 0
 
   name        = "${lower(var.service_name)}-owasp-06-detect-php-insecure-${random_id.this.0.hex}"
   metric_name = "${lower(var.service_name)}OWASP06DetectPHPInsecure${random_id.this.0.hex}"
@@ -1307,14 +1307,14 @@ resource "aws_waf_rule" "owasp_06_php_insecure_rule" {
 ### Mitigate abnormal requests via size restrictions
 ### Enforce consistent request hygene, limit size of key elements
 resource "aws_waf_size_constraint_set" "owasp_07_size_restriction_set" {
-  count = "${lower(var.target_scope) == "global" ? "1" : "0"}"
+  count = lower(var.target_scope) == "global" ? 1 : 0
 
   name = "${lower(var.service_name)}-owasp-07-size-restrictions-${random_id.this.0.hex}"
 
   size_constraints {
     text_transformation = "NONE"
     comparison_operator = "GT"
-    size                = "${var.max_expected_uri_size}"
+    size                = var.max_expected_uri_size
 
     field_to_match {
       type = "URI"
@@ -1324,7 +1324,7 @@ resource "aws_waf_size_constraint_set" "owasp_07_size_restriction_set" {
   size_constraints {
     text_transformation = "NONE"
     comparison_operator = "GT"
-    size                = "${var.max_expected_query_string_size}"
+    size                = var.max_expected_query_string_size
 
     field_to_match {
       type = "QUERY_STRING"
@@ -1334,7 +1334,7 @@ resource "aws_waf_size_constraint_set" "owasp_07_size_restriction_set" {
   size_constraints {
     text_transformation = "NONE"
     comparison_operator = "GT"
-    size                = "${var.max_expected_body_size}"
+    size                = var.max_expected_body_size
 
     field_to_match {
       type = "BODY"
@@ -1344,7 +1344,7 @@ resource "aws_waf_size_constraint_set" "owasp_07_size_restriction_set" {
   size_constraints {
     text_transformation = "NONE"
     comparison_operator = "GT"
-    size                = "${var.max_expected_cookie_size}"
+    size                = var.max_expected_cookie_size
 
     field_to_match {
       type = "HEADER"
@@ -1356,13 +1356,13 @@ resource "aws_waf_size_constraint_set" "owasp_07_size_restriction_set" {
 resource "aws_waf_rule" "owasp_07_size_restriction_rule" {
   depends_on = ["aws_waf_size_constraint_set.owasp_07_size_restriction_set"]
 
-  count = "${lower(var.target_scope) == "global" ? "1" : "0"}"
+  count = lower(var.target_scope) == "global" ? 1 : 0
 
   name        = "${lower(var.service_name)}-owasp-07-restrict-sizes-${random_id.this.0.hex}"
   metric_name = "${lower(var.service_name)}OWASP07RestrictSizes${random_id.this.0.hex}"
 
   predicates {
-    data_id = "${aws_waf_size_constraint_set.owasp_07_size_restriction_set.0.id}"
+    data_id = aws_waf_size_constraint_set.owasp_07_size_restriction_set.0.id
     negated = "false"
     type    = "SizeConstraint"
   }
@@ -1372,7 +1372,7 @@ resource "aws_waf_rule" "owasp_07_size_restriction_rule" {
 ### CSRF token enforcement example
 ### Enforce the presence of CSRF token in request header
 resource "aws_waf_byte_match_set" "owasp_08_csrf_method_string_set" {
-  count = "${lower(var.target_scope) == "global" ? "1" : "0"}"
+  count = lower(var.target_scope) == "global" ? 1 : 0
 
   name = "${lower(var.service_name)}-owasp-08-match-csrf-method-${random_id.this.0.hex}"
 
@@ -1388,7 +1388,7 @@ resource "aws_waf_byte_match_set" "owasp_08_csrf_method_string_set" {
 }
 
 resource "aws_waf_size_constraint_set" "owasp_08_csrf_token_size_constrain_set" {
-  count = "${lower(var.target_scope) == "global" ? "1" : "0"}"
+  count = lower(var.target_scope) == "global" ? 1 : 0
 
   name = "${lower(var.service_name)}-owasp-08-csrf-token-size-${random_id.this.0.hex}"
 
@@ -1407,13 +1407,13 @@ resource "aws_waf_size_constraint_set" "owasp_08_csrf_token_size_constrain_set" 
 resource "aws_waf_rule" "owasp_08_csrf_rule" {
   depends_on = ["aws_waf_byte_match_set.owasp_08_csrf_method_string_set", "aws_waf_size_constraint_set.owasp_08_csrf_token_size_constrain_set"]
 
-  count = "${lower(var.target_scope) == "global" ? "1" : "0"}"
+  count = lower(var.target_scope) == "global" ? 1 : 0
 
   name        = "${lower(var.service_name)}-owasp-08-enforce-csrf-${random_id.this.0.hex}"
   metric_name = "${lower(var.service_name)}OWASP08EnforceCSRF${random_id.this.0.hex}"
 
   predicates {
-    data_id = "${aws_waf_byte_match_set.owasp_08_csrf_method_string_set.0.id}"
+    data_id = aws_waf_byte_match_set.owasp_08_csrf_method_string_set.0.id
     negated = "false"
     type    = "ByteMatch"
   }
@@ -1429,7 +1429,7 @@ resource "aws_waf_rule" "owasp_08_csrf_rule" {
 ### Server-side includes & libraries in webroot
 ### Matches request patterns for webroot objects that shouldn't be directly accessible
 resource "aws_waf_byte_match_set" "owasp_09_server_side_include_string_set" {
-  count = "${lower(var.target_scope) == "global" ? "1" : "0"}"
+  count = lower(var.target_scope) == "global" ? 1 : 0
 
   name = "${lower(var.service_name)}-owasp-09-match-ssi-${random_id.this.0.hex}"
 
@@ -1507,13 +1507,13 @@ resource "aws_waf_byte_match_set" "owasp_09_server_side_include_string_set" {
 resource "aws_waf_rule" "owasp_09_server_side_include_rule" {
   depends_on = ["aws_waf_byte_match_set.owasp_09_server_side_include_string_set"]
 
-  count = "${lower(var.target_scope) == "global" ? "1" : "0"}"
+  count = lower(var.target_scope) == "global" ? 1 : 0
 
   name        = "${lower(var.service_name)}-owasp-09-detect-ssi-${random_id.this.0.hex}"
   metric_name = "${lower(var.service_name)}OWASP09DetectSSI${random_id.this.0.hex}"
 
   predicates {
-    data_id = "${aws_waf_byte_match_set.owasp_09_server_side_include_string_set.0.id}"
+    data_id = aws_waf_byte_match_set.owasp_09_server_side_include_string_set.0.id
     negated = "false"
     type    = "ByteMatch"
   }
@@ -1538,10 +1538,10 @@ resource "aws_waf_rule_group" "owasp_top_10" {
     "aws_waf_rule.owasp_09_server_side_include_rule",
   ]
 
-  count = "${lower(var.create_rule_group) && lower(var.target_scope) == "global" ? "1" : "0"}"
+  count = lower(var.create_rule_group) && lower(var.target_scope) == "global" ? 1 : 0
 
-  name        = "${format("%s-owasp-top-10-%s", lower(var.service_name), random_id.this.0.hex)}"
-  metric_name = "${format("%sOWASPTop10%s", lower(var.service_name), random_id.this.0.hex)}"
+  name        = format("%s-owasp-top-10-%s", lower(var.service_name), random_id.this.0.hex)
+  metric_name = format("%sOWASPTop10%s", lower(var.service_name), random_id.this.0.hex)
 
   activated_rule {
     action {
@@ -1549,7 +1549,7 @@ resource "aws_waf_rule_group" "owasp_top_10" {
     }
 
     priority = "1"
-    rule_id  = "${aws_waf_rule.owasp_07_size_restriction_rule.0.id}"
+    rule_id  = aws_waf_rule.owasp_07_size_restriction_rule.0.id
     type     = "REGULAR"
   }
 
@@ -1559,7 +1559,7 @@ resource "aws_waf_rule_group" "owasp_top_10" {
     }
 
     priority = "2"
-    rule_id  = "${aws_waf_rule.owasp_02_auth_token_rule.0.id}"
+    rule_id  = aws_waf_rule.owasp_02_auth_token_rule.0.id
     type     = "REGULAR"
   }
 
@@ -1569,7 +1569,7 @@ resource "aws_waf_rule_group" "owasp_top_10" {
     }
 
     priority = "3"
-    rule_id  = "${aws_waf_rule.owasp_01_sql_injection_rule.0.id}"
+    rule_id  = aws_waf_rule.owasp_01_sql_injection_rule.0.id
     type     = "REGULAR"
   }
 
@@ -1579,7 +1579,7 @@ resource "aws_waf_rule_group" "owasp_top_10" {
     }
 
     priority = "4"
-    rule_id  = "${aws_waf_rule.owasp_03_xss_rule.0.id}"
+    rule_id  = aws_waf_rule.owasp_03_xss_rule.0.id
     type     = "REGULAR"
   }
 
@@ -1589,7 +1589,7 @@ resource "aws_waf_rule_group" "owasp_top_10" {
     }
 
     priority = "5"
-    rule_id  = "${aws_waf_rule.owasp_04_paths_rule.0.id}"
+    rule_id  = aws_waf_rule.owasp_04_paths_rule.0.id
     type     = "REGULAR"
   }
 
@@ -1599,7 +1599,7 @@ resource "aws_waf_rule_group" "owasp_top_10" {
     }
 
     priority = "6"
-    rule_id  = "${aws_waf_rule.owasp_06_php_insecure_rule.0.id}"
+    rule_id  = aws_waf_rule.owasp_06_php_insecure_rule.0.id
     type     = "REGULAR"
   }
 
@@ -1609,7 +1609,7 @@ resource "aws_waf_rule_group" "owasp_top_10" {
     }
 
     priority = "7"
-    rule_id  = "${aws_waf_rule.owasp_08_csrf_rule.0.id}"
+    rule_id  = aws_waf_rule.owasp_08_csrf_rule.0.id
     type     = "REGULAR"
   }
 
@@ -1619,7 +1619,7 @@ resource "aws_waf_rule_group" "owasp_top_10" {
     }
 
     priority = "8"
-    rule_id  = "${aws_waf_rule.owasp_09_server_side_include_rule.0.id}"
+    rule_id  = aws_waf_rule.owasp_09_server_side_include_rule.0.id
     type     = "REGULAR"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -256,7 +256,7 @@ resource "aws_wafregional_rule" "owasp_03_xss_rule" {
   metric_name = "${lower(var.service_name)}OWASP03MitigateXSS${random_id.this.0.hex}"
 
   predicate {
-    data_id = "${aws_wafregional_xss_match_set.owasp_03_xss_set.0.id}"
+    data_id = aws_wafregional_xss_match_set.owasp_03_xss_set.0.id
     negated = "false"
     type    = "XssMatch"
   }

--- a/main.tf
+++ b/main.tf
@@ -360,7 +360,7 @@ resource "aws_wafregional_rule" "owasp_04_paths_rule" {
   metric_name = "${lower(var.service_name)}OWASP04DetectRFILFITraversal${random_id.this.0.hex}"
 
   predicate {
-    data_id = "${aws_wafregional_byte_match_set.owasp_04_paths_string_set.0.id}"
+    data_id = aws_wafregional_byte_match_set.owasp_04_paths_string_set.0.id
     negated = "false"
     type    = "ByteMatch"
   }
@@ -496,13 +496,13 @@ resource "aws_wafregional_rule" "owasp_06_php_insecure_rule" {
   metric_name = "${lower(var.service_name)}OWASP06DetectPHPInsecure${random_id.this.0.hex}"
 
   predicate {
-    data_id = "${aws_wafregional_byte_match_set.owasp_06_php_insecure_qs_string_set.0.id}"
+    data_id = aws_wafregional_byte_match_set.owasp_06_php_insecure_qs_string_set.0.id
     negated = "false"
     type    = "ByteMatch"
   }
 
   predicate {
-    data_id = "${aws_wafregional_byte_match_set.owasp_06_php_insecure_uri_string_set.0.id}"
+    data_id = aws_wafregional_byte_match_set.owasp_06_php_insecure_uri_string_set.0.id
     negated = "false"
     type    = "ByteMatch"
   }
@@ -618,7 +618,7 @@ resource "aws_wafregional_rule" "owasp_08_csrf_rule" {
   metric_name = "${lower(var.service_name)}OWASP08EnforceCSRF${random_id.this.0.hex}"
 
   predicate {
-    data_id = "${aws_wafregional_byte_match_set.owasp_08_csrf_method_string_set.0.id}"
+    data_id = aws_wafregional_byte_match_set.owasp_08_csrf_method_string_set.0.id
     negated = "false"
     type    = "ByteMatch"
   }
@@ -959,7 +959,7 @@ resource "aws_waf_rule" "owasp_02_auth_token_rule" {
   metric_name = "${lower(var.service_name)}OWASP02BadAuthToken${random_id.this.0.hex}"
 
   predicates {
-    data_id = "${aws_waf_byte_match_set.owasp_02_auth_token_string_set.0.id}"
+    data_id = aws_waf_byte_match_set.owasp_02_auth_token_string_set.0.id
     negated = "false"
     type    = "ByteMatch"
   }
@@ -1049,7 +1049,7 @@ resource "aws_waf_rule" "owasp_03_xss_rule" {
   metric_name = "${lower(var.service_name)}OWASP03MitigateXSS${random_id.this.0.hex}"
 
   predicates {
-    data_id = "${aws_waf_xss_match_set.owasp_03_xss_set.0.id}"
+    data_id = aws_waf_xss_match_set.owasp_03_xss_set.0.id
     negated = "false"
     type    = "XssMatch"
   }
@@ -1153,7 +1153,7 @@ resource "aws_waf_rule" "owasp_04_paths_rule" {
   metric_name = "${lower(var.service_name)}OWASP04DetectRFILFITraversal${random_id.this.0.hex}"
 
   predicates {
-    data_id = "${aws_waf_byte_match_set.owasp_04_paths_string_set.0.id}"
+    data_id = aws_waf_byte_match_set.owasp_04_paths_string_set.0.id
     negated = "false"
     type    = "ByteMatch"
   }
@@ -1289,13 +1289,13 @@ resource "aws_waf_rule" "owasp_06_php_insecure_rule" {
   metric_name = "${lower(var.service_name)}OWASP06DetectPHPInsecure${random_id.this.0.hex}"
 
   predicates {
-    data_id = "${aws_waf_byte_match_set.owasp_06_php_insecure_qs_string_set.0.id}"
+    data_id = aws_waf_byte_match_set.owasp_06_php_insecure_qs_string_set.0.id
     negated = "false"
     type    = "ByteMatch"
   }
 
   predicates {
-    data_id = "${aws_waf_byte_match_set.owasp_06_php_insecure_uri_string_set.0.id}"
+    data_id = aws_waf_byte_match_set.owasp_06_php_insecure_uri_string_set.0.id
     negated = "false"
     type    = "ByteMatch"
   }
@@ -1417,7 +1417,7 @@ resource "aws_waf_rule" "owasp_08_csrf_rule" {
   }
 
   predicates {
-    data_id = "${aws_waf_size_constraint_set.owasp_08_csrf_token_size_constrain_set.0.id}"
+    data_id = aws_waf_size_constraint_set.owasp_08_csrf_token_size_constrain_set.0.id
     negated = "false"
     type    = "SizeConstraint"
   }

--- a/main.tf
+++ b/main.tf
@@ -134,7 +134,7 @@ resource "aws_wafregional_byte_match_set" "owasp_02_auth_token_string_set" {
 }
 
 resource "aws_wafregional_rule" "owasp_02_auth_token_rule" {
-  depends_on = ["aws_wafregional_byte_match_set.owasp_02_auth_token_string_set"]
+  depends_on = [aws_wafregional_byte_match_set.owasp_02_auth_token_string_set]
 
   count = lower(var.target_scope) == "regional" ? 1 : 0
 
@@ -248,7 +248,7 @@ resource "aws_wafregional_xss_match_set" "owasp_03_xss_set" {
 }
 
 resource "aws_wafregional_rule" "owasp_03_xss_rule" {
-  depends_on = ["aws_wafregional_xss_match_set.owasp_03_xss_set"]
+  depends_on = [aws_wafregional_xss_match_set.owasp_03_xss_set]
 
   count = lower(var.target_scope) == "regional" ? 1 : 0
 
@@ -352,7 +352,7 @@ resource "aws_wafregional_byte_match_set" "owasp_04_paths_string_set" {
 }
 
 resource "aws_wafregional_rule" "owasp_04_paths_rule" {
-  depends_on = ["aws_wafregional_byte_match_set.owasp_04_paths_string_set"]
+  depends_on = [aws_wafregional_byte_match_set.owasp_04_paths_string_set]
 
   count = lower(var.target_scope) == "regional" ? 1 : 0
 
@@ -488,7 +488,7 @@ resource "aws_wafregional_byte_match_set" "owasp_06_php_insecure_uri_string_set"
 }
 
 resource "aws_wafregional_rule" "owasp_06_php_insecure_rule" {
-  depends_on = ["aws_wafregional_byte_match_set.owasp_06_php_insecure_qs_string_set", "aws_wafregional_byte_match_set.owasp_06_php_insecure_uri_string_set"]
+  depends_on = [aws_wafregional_byte_match_set.owasp_06_php_insecure_qs_string_set, aws_wafregional_byte_match_set.owasp_06_php_insecure_uri_string_set]
 
   count = lower(var.target_scope) == "regional" ? 1 : 0
 
@@ -559,7 +559,7 @@ resource "aws_wafregional_size_constraint_set" "owasp_07_size_restriction_set" {
 }
 
 resource "aws_wafregional_rule" "owasp_07_size_restriction_rule" {
-  depends_on = ["aws_wafregional_size_constraint_set.owasp_07_size_restriction_set"]
+  depends_on = [aws_wafregional_size_constraint_set.owasp_07_size_restriction_set]
 
   count = lower(var.target_scope) == "regional" ? 1 : 0
 
@@ -610,7 +610,7 @@ resource "aws_wafregional_size_constraint_set" "owasp_08_csrf_token_size_constra
 }
 
 resource "aws_wafregional_rule" "owasp_08_csrf_rule" {
-  depends_on = ["aws_wafregional_byte_match_set.owasp_08_csrf_method_string_set", "aws_wafregional_size_constraint_set.owasp_08_csrf_token_size_constrain_set"]
+  depends_on = [aws_wafregional_byte_match_set.owasp_08_csrf_method_string_set, aws_wafregional_size_constraint_set.owasp_08_csrf_token_size_constrain_set]
 
   count = lower(var.target_scope) == "regional" ? 1 : 0
 
@@ -710,7 +710,7 @@ resource "aws_wafregional_byte_match_set" "owasp_09_server_side_include_string_s
 }
 
 resource "aws_wafregional_rule" "owasp_09_server_side_include_rule" {
-  depends_on = ["aws_wafregional_byte_match_set.owasp_09_server_side_include_string_set"]
+  depends_on = [aws_wafregional_byte_match_set.owasp_09_server_side_include_string_set]
 
   count = lower(var.target_scope) == "regional" ? 1 : 0
 
@@ -733,14 +733,14 @@ resource "aws_wafregional_rule" "owasp_09_server_side_include_rule" {
 
 resource "aws_wafregional_rule_group" "owasp_top_10" {
   depends_on = [
-    "aws_wafregional_rule.owasp_01_sql_injection_rule",
-    "aws_wafregional_rule.owasp_02_auth_token_rule",
-    "aws_wafregional_rule.owasp_03_xss_rule",
-    "aws_wafregional_rule.owasp_04_paths_rule",
-    "aws_wafregional_rule.owasp_06_php_insecure_rule",
-    "aws_wafregional_rule.owasp_07_size_restriction_rule",
-    "aws_wafregional_rule.owasp_08_csrf_rule",
-    "aws_wafregional_rule.owasp_09_server_side_include_rule",
+    aws_wafregional_rule.owasp_01_sql_injection_rule,
+    aws_wafregional_rule.owasp_02_auth_token_rule,
+    aws_wafregional_rule.owasp_03_xss_rule,
+    aws_wafregional_rule.owasp_04_paths_rule,
+    aws_wafregional_rule.owasp_06_php_insecure_rule,
+    aws_wafregional_rule.owasp_07_size_restriction_rule,
+    aws_wafregional_rule.owasp_08_csrf_rule,
+    aws_wafregional_rule.owasp_09_server_side_include_rule,
   ]
 
   count = lower(var.create_rule_group) && lower(var.target_scope) == "regional" ? 1 : 0
@@ -951,7 +951,7 @@ resource "aws_waf_byte_match_set" "owasp_02_auth_token_string_set" {
 }
 
 resource "aws_waf_rule" "owasp_02_auth_token_rule" {
-  depends_on = ["aws_waf_byte_match_set.owasp_02_auth_token_string_set"]
+  depends_on = [aws_waf_byte_match_set.owasp_02_auth_token_string_set]
 
   count = lower(var.target_scope) == "global" ? 1 : 0
 
@@ -1041,7 +1041,7 @@ resource "aws_waf_xss_match_set" "owasp_03_xss_set" {
 }
 
 resource "aws_waf_rule" "owasp_03_xss_rule" {
-  depends_on = ["aws_waf_xss_match_set.owasp_03_xss_set"]
+  depends_on = [aws_waf_xss_match_set.owasp_03_xss_set]
 
   count = lower(var.target_scope) == "global" ? 1 : 0
 
@@ -1169,7 +1169,7 @@ resource "aws_waf_byte_match_set" "owasp_04_paths_string_set" {
 }
 
 resource "aws_waf_rule" "owasp_04_paths_rule" {
-  depends_on = ["aws_waf_byte_match_set.owasp_04_paths_string_set"]
+  depends_on = [aws_waf_byte_match_set.owasp_04_paths_string_set]
 
   count = lower(var.target_scope) == "global" ? 1 : 0
 
@@ -1305,7 +1305,7 @@ resource "aws_waf_byte_match_set" "owasp_06_php_insecure_uri_string_set" {
 }
 
 resource "aws_waf_rule" "owasp_06_php_insecure_rule" {
-  depends_on = ["aws_waf_byte_match_set.owasp_06_php_insecure_qs_string_set", "aws_waf_byte_match_set.owasp_06_php_insecure_uri_string_set"]
+  depends_on = [aws_waf_byte_match_set.owasp_06_php_insecure_qs_string_set, aws_waf_byte_match_set.owasp_06_php_insecure_uri_string_set]
 
   count = lower(var.target_scope) == "global" ? 1 : 0
 
@@ -1376,7 +1376,7 @@ resource "aws_waf_size_constraint_set" "owasp_07_size_restriction_set" {
 }
 
 resource "aws_waf_rule" "owasp_07_size_restriction_rule" {
-  depends_on = ["aws_waf_size_constraint_set.owasp_07_size_restriction_set"]
+  depends_on = [aws_waf_size_constraint_set.owasp_07_size_restriction_set]
 
   count = lower(var.target_scope) == "global" ? 1 : 0
 
@@ -1427,7 +1427,7 @@ resource "aws_waf_size_constraint_set" "owasp_08_csrf_token_size_constrain_set" 
 }
 
 resource "aws_waf_rule" "owasp_08_csrf_rule" {
-  depends_on = ["aws_waf_byte_match_set.owasp_08_csrf_method_string_set", "aws_waf_size_constraint_set.owasp_08_csrf_token_size_constrain_set"]
+  depends_on = [aws_waf_byte_match_set.owasp_08_csrf_method_string_set, aws_waf_size_constraint_set.owasp_08_csrf_token_size_constrain_set]
 
   count = lower(var.target_scope) == "global" ? 1 : 0
 
@@ -1527,7 +1527,7 @@ resource "aws_waf_byte_match_set" "owasp_09_server_side_include_string_set" {
 }
 
 resource "aws_waf_rule" "owasp_09_server_side_include_rule" {
-  depends_on = ["aws_waf_byte_match_set.owasp_09_server_side_include_string_set"]
+  depends_on = [aws_waf_byte_match_set.owasp_09_server_side_include_string_set]
 
   count = lower(var.target_scope) == "global" ? 1 : 0
 
@@ -1550,14 +1550,14 @@ resource "aws_waf_rule" "owasp_09_server_side_include_rule" {
 
 resource "aws_waf_rule_group" "owasp_top_10" {
   depends_on = [
-    "aws_waf_rule.owasp_01_sql_injection_rule",
-    "aws_waf_rule.owasp_02_auth_token_rule",
-    "aws_waf_rule.owasp_03_xss_rule",
-    "aws_waf_rule.owasp_04_paths_rule",
-    "aws_waf_rule.owasp_06_php_insecure_rule",
-    "aws_waf_rule.owasp_07_size_restriction_rule",
-    "aws_waf_rule.owasp_08_csrf_rule",
-    "aws_waf_rule.owasp_09_server_side_include_rule",
+    aws_waf_rule.owasp_01_sql_injection_rule,
+    aws_waf_rule.owasp_02_auth_token_rule,
+    aws_waf_rule.owasp_03_xss_rule,
+    aws_waf_rule.owasp_04_paths_rule,
+    aws_waf_rule.owasp_06_php_insecure_rule,
+    aws_waf_rule.owasp_07_size_restriction_rule,
+    aws_waf_rule.owasp_08_csrf_rule,
+    aws_waf_rule.owasp_09_server_side_include_rule,
   ]
 
   count = lower(var.create_rule_group) && lower(var.target_scope) == "global" ? 1 : 0

--- a/variables.tf
+++ b/variables.tf
@@ -64,3 +64,51 @@ variable "csrf_expected_size" {
   description = "The size in bytes of the CSRF token value. For example if it's a canonically formatted UUIDv4 value the expected size would be 36 bytes/ASCII characters."
   default     = "36"
 }
+
+variable "disable_xss_uri_url_decode" {
+  default     = false
+  type        = bool
+  description = "Disable the 'URI contains a cross-site scripting threat after decoding as URL.' filter."
+}
+
+variable "disable_xss_uri_html_decode" {
+  default     = false
+  type        = bool
+  description = "Disable the 'URI contains a cross-site scripting threat after decoding as HTML tags.' filter."
+}
+
+variable "disable_xss_query_string_url_decode" {
+  default     = false
+  type        = bool
+  description = "Disable the 'Query string contains a cross-site scripting threat after decoding as URL.' filter."
+}
+
+variable "disable_xss_query_string_html_decode" {
+  default     = false
+  type        = bool
+  description = "Disable the 'Query string contains a cross-site scripting threat after decoding as HTML tags.' filter."
+}
+
+variable "disable_xss_body_url_decode" {
+  default     = false
+  type        = bool
+  description = "Disable the 'Body contains a cross-site scripting threat after decoding as URL.' filter."
+}
+
+variable "disable_xss_body_html_decode" {
+  default     = false
+  type        = bool
+  description = "Disable the 'Body contains a cross-site scripting threat after decoding as HTML tags.' filter."
+}
+
+variable "disable_xss_cookie_url_decode" {
+  default     = false
+  type        = bool
+  description = "Disable the 'Header cookie contains a cross-site scripting threat after decoding as URL.' filter."
+}
+
+variable "disable_xss_cookie_html_decode" {
+  default     = false
+  type        = bool
+  description = "Disable the 'Header 'cookie' contains a cross-site scripting threat after decoding as HTML tags.' filter."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,66 +1,66 @@
 variable "product_domain" {
-  type        = "string"
+  type        = string
   description = "The name of the product domain these resources belong to."
 }
 
 variable "service_name" {
-  type        = "string"
+  type        = string
   description = "The name of the service these resources belong to."
 }
 
 variable "environment" {
-  type        = "string"
+  type        = string
   description = "The environment of these resources belong to."
 }
 
 variable "description" {
-  type        = "string"
+  type        = string
   description = "The description of these resources."
 }
 
 variable "target_scope" {
-  type        = "string"
+  type        = string
   description = "Valid values are `global` and `regional`. If `global`, means resources created will be for global targets such as Amazon CloudFront distribution. For regional targets like ALBs and API Gateway stages, set to `regional`"
 }
 
 variable "create_rule_group" {
-  type        = "string"
+  type        = string
   description = "All rules can be grouped into a Rule Group. Unfortunately, AWS WAF Rule Group limit per region is only 3. By setting the value to `false` will not create the rule group. Default to `true`."
   default     = "true"
 }
 
 variable "max_expected_uri_size" {
-  type        = "string"
+  type        = string
   description = "Maximum number of bytes allowed in the URI component of the HTTP request. Generally the maximum possible value is determined by the server operating system (maps to file system paths), the web server software, or other middleware components. Choose a value that accomodates the largest URI segment you use in practice in your web application."
   default     = "512"
 }
 
 variable "max_expected_query_string_size" {
-  type        = "string"
+  type        = string
   description = "Maximum number of bytes allowed in the query string component of the HTTP request. Normally the  of query string parameters following the ? in a URL is much larger than the URI , but still bounded by the  of the parameters your web application uses and their values."
   default     = "1024"
 }
 
 variable "max_expected_body_size" {
-  type        = "string"
+  type        = string
   description = "Maximum number of bytes allowed in the body of the request. If you do not plan to allow large uploads, set it to the largest payload value that makes sense for your web application. Accepting unnecessarily large values can cause performance issues, if large payloads are used as an attack vector against your web application."
   default     = "4096"
 }
 
 variable "max_expected_cookie_size" {
-  type        = "string"
+  type        = string
   description = "Maximum number of bytes allowed in the cookie header. The maximum size should be less than 4096, the size is determined by the amount of information your web application stores in cookies. If you only pass a session token via cookies, set the size to no larger than the serialized size of the session token and cookie metadata."
   default     = "4093"
 }
 
 variable "csrf_expected_header" {
-  type        = "string"
+  type        = string
   description = "The custom HTTP request header, where the CSRF token value is expected to be encountered"
   default     = "x-csrf-token"
 }
 
 variable "csrf_expected_size" {
-  type        = "string"
+  type        = string
   description = "The size in bytes of the CSRF token value. For example if it's a canonically formatted UUIDv4 value the expected size would be 36 bytes/ASCII characters."
   default     = "36"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -112,3 +112,51 @@ variable "disable_xss_cookie_html_decode" {
   type        = bool
   description = "Disable the 'Header 'cookie' contains a cross-site scripting threat after decoding as HTML tags.' filter."
 }
+
+variable "disable_04_uri_contains_previous_dir_after_url_decode" {
+  default     = false
+  type        = bool
+  description = "Disable the 'URI contains: '../' after decoding as URL.' filter"
+}
+
+variable "disable_04_uri_contains_previous_dir_after_html_decode" {
+  default     = false
+  type        = bool
+  description = "Disable the 'URI contains: '../' after decoding as HTML tags.' filter"
+}
+
+variable "disable_04_query_string_contains_previous_dir_after_url_decode" {
+  default     = false
+  type        = bool
+  description = "Disable the 'Query string contains: '../' after decoding as URL.' filter"
+}
+
+variable "disable_04_query_string_contains_previous_dir_after_html_decode" {
+  default     = false
+  type        = bool
+  description = "Disable the 'Query string contains: '../' after decoding as HTML tags.' filter"
+}
+
+variable "disable_04_uri_contains_url_path_after_url_decode" {
+  default     = false
+  type        = bool
+  description = "Disable the 'URI contains: '://' after decoding as URL.' filter"
+}
+
+variable "disable_04_uri_contains_url_path_after_html_decode" {
+  default     = false
+  type        = bool
+  description = "Disable the 'URI contains: '://' after decoding as HTML tags.' filter"
+}
+
+variable "disable_04_query_string_contains_url_path_after_url_decode" {
+  default     = false
+  type        = bool
+  description = "Disable the 'Query string contains: '://' after decoding as URL.' filter"
+}
+
+variable "disable_04_query_string_contains_url_path_after_html_decode" {
+  default     = false
+  type        = bool
+  description = "Disable the 'Query string contains: '://' after decoding as HTML tags.' filter"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -65,49 +65,49 @@ variable "csrf_expected_size" {
   default     = "36"
 }
 
-variable "disable_xss_uri_url_decode" {
+variable "disable_03_uri_url_decode" {
   default     = false
   type        = bool
   description = "Disable the 'URI contains a cross-site scripting threat after decoding as URL.' filter."
 }
 
-variable "disable_xss_uri_html_decode" {
+variable "disable_03_uri_html_decode" {
   default     = false
   type        = bool
   description = "Disable the 'URI contains a cross-site scripting threat after decoding as HTML tags.' filter."
 }
 
-variable "disable_xss_query_string_url_decode" {
+variable "disable_03_query_string_url_decode" {
   default     = false
   type        = bool
   description = "Disable the 'Query string contains a cross-site scripting threat after decoding as URL.' filter."
 }
 
-variable "disable_xss_query_string_html_decode" {
+variable "disable_03_query_string_html_decode" {
   default     = false
   type        = bool
   description = "Disable the 'Query string contains a cross-site scripting threat after decoding as HTML tags.' filter."
 }
 
-variable "disable_xss_body_url_decode" {
+variable "disable_03_body_url_decode" {
   default     = false
   type        = bool
   description = "Disable the 'Body contains a cross-site scripting threat after decoding as URL.' filter."
 }
 
-variable "disable_xss_body_html_decode" {
+variable "disable_03_body_html_decode" {
   default     = false
   type        = bool
   description = "Disable the 'Body contains a cross-site scripting threat after decoding as HTML tags.' filter."
 }
 
-variable "disable_xss_cookie_url_decode" {
+variable "disable_03_cookie_url_decode" {
   default     = false
   type        = bool
   description = "Disable the 'Header cookie contains a cross-site scripting threat after decoding as URL.' filter."
 }
 
-variable "disable_xss_cookie_html_decode" {
+variable "disable_03_cookie_html_decode" {
   default     = false
   type        = bool
   description = "Disable the 'Header 'cookie' contains a cross-site scripting threat after decoding as HTML tags.' filter."


### PR DESCRIPTION
<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***


***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-waf-owasp-top-10-rules/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NOTES:

* Updates to address all Terraform 0.12 warnings
* Updates to allow disabling specific XSS rules

FEATURES:

*  Feature: Updates to allow disabling specific XSS rules

BUG FIXES:

* Updates to address all Terraform 0.12 warnings
```
