### PR TITLE
remove a RFI LFI filter

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -307,16 +307,6 @@ resource "aws_wafregional_byte_match_set" "owasp_04_paths_string_set" {
   }
 
   byte_match_tuples {
-    text_transformation   = "URL_DECODE"
-    target_string         = "://"
-    positional_constraint = "CONTAINS"
-
-    field_to_match {
-      type = "QUERY_STRING"
-    }
-  }
-
-  byte_match_tuples {
     text_transformation   = "HTML_ENTITY_DECODE"
     target_string         = "://"
     positional_constraint = "CONTAINS"
@@ -1098,16 +1088,6 @@ resource "aws_waf_byte_match_set" "owasp_04_paths_string_set" {
 
     field_to_match {
       type = "URI"
-    }
-  }
-
-  byte_match_tuples {
-    text_transformation   = "URL_DECODE"
-    target_string         = "://"
-    positional_constraint = "CONTAINS"
-
-    field_to_match {
-      type = "QUERY_STRING"
     }
   }
 


### PR DESCRIPTION
Removing the filter for `Query string contains: "://" after decoding as URL.`

It's very common nowadays to put a `url` for purposes like `redirect` or `iss`(issuer by auth providers) in the query params.
This filter is generating lots of false positives

<!--- 
See how to make a good Pull Request at : https://github.blog/2015-01-21-how-to-write-the-perfect-pull-request/ 
--->

### Community Note
<!---
No need to modify anything within this section.
--->
* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

***

***

Release note for [CHANGELOG](https://github.com/traveloka/terraform-aws-waf-owasp-top-10-rules/blob/master/CHANGELOG.md):
<!--
If the changes are not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NOTES:

* Removes a filter `Query string contains: "://" after decoding as URL.` from `owasp-04-detect-rfi-lfi-traversal` rule

***
